### PR TITLE
Fix conversion factor with no decimals

### DIFF
--- a/aws/Makefile
+++ b/aws/Makefile
@@ -277,6 +277,7 @@ deploy-wallet:
 		cp tmp/wallet/commitment-storage.js nightfall_3/wallet/src//nightfall-browser/services/commitment-storage.js; \
 		cp tmp/wallet/TokenType.ts nightfall_3/wallet/src/static/supported-token-lists; \
 		cp tmp/wallet/walletIndex.jsx nightfall_3/wallet/src/views/wallet/index.jsx; \
+		cp tmp/wallet/local-storage.js nightfall_3/wallet/src/utils/lib/local-storage.js; \
 		cp tmp/config/default.js nightfall_3/config/default.js; \
 	fi
 	cd scripts && RELEASE=${RELEASE} ./deploy-wallet.sh
@@ -295,6 +296,7 @@ deploy-wallet-local:
 		cp tmp/wallet/commitment-storage.js nightfall_3/wallet/src//nightfall-browser/services/commitment-storage.js; \
 		cp tmp/wallet/TokenType.ts nightfall_3/wallet/src/static/supported-token-lists; \
 		cp tmp/wallet/walletIndex.jsx nightfall_3/wallet/src/views/wallet/index.jsx; \
+		cp tmp/wallet/local-storage.js nightfall_3/wallet/src/utils/lib/local-storage.js; \
 		cp tmp/config/default.js nightfall_3/config/default.js; \
 	fi
 	cd scripts && RELEASE=${RELEASE} ./deploy-wallet-local.sh

--- a/aws/test/wallet/edge-tokens.mjs
+++ b/aws/test/wallet/edge-tokens.mjs
@@ -41,7 +41,7 @@ function newRlnToken(rlnToken, rlnTokenId) {
     address: RLN_CONTRACT_ADDRESS,
     logoURI: 'https://wallet-asset.matic.network/img/tokens/usdc.svg',
     tags: ['pos', 'erc20', 'swapable', 'metaTx'],
-    id: 'ethereum',
+    id: '',
     restrictions: {
       withdraw: '1000000000',
       deposit: '250000000',

--- a/aws/tmp/wallet/TokenItemIndex.jsx
+++ b/aws/tmp/wallet/TokenItemIndex.jsx
@@ -99,8 +99,8 @@ export default function TokenItem(props) {
                       .mul(props.currencyValue)
                       .toFixed(4)
                   : new BigFloat(
-                      String(filteredTokens[filteredTokenIdx].l2Balance ?? 0),
-                      props.decimals,
+                      String(filteredTokens[filteredTokenIdx].l2Balance ?? 0).concat('.0000'),
+                      4,
                     )
                       .mul(props.currencyValue)
                       .toFixed(4)}

--- a/aws/tmp/wallet/TransactionsIndex.jsx
+++ b/aws/tmp/wallet/TransactionsIndex.jsx
@@ -347,8 +347,12 @@ const Transactions = () => {
                         }}
                       >
                         $
-                        {new BigFloat(BigInt(tx.value), tx.decimals)
-                          .mul(tx.currencyValue)
+                        {tx.decimals
+                          ? new BigFloat(BigInt(tx.value), tx.decimals)
+                              .mul(tx.currencyValue)
+                              .toFixed(4)
+                          : new BigFloat(String(tx.value ?? 0).concat('.0000'), 4)
+                              .mul(tx.currencyValue)
                           .toFixed(4)}
                       </div>
                     </div>

--- a/aws/tmp/wallet/local-storage.js
+++ b/aws/tmp/wallet/local-storage.js
@@ -1,0 +1,109 @@
+/* ignore unused exports */
+
+import { getContractAddress } from '../../common-files/utils/contract';
+import getPrice from '../pricingAPI';
+
+const STORAGE_VERSION_KEY = 'nightfallStorageVersion';
+const STORAGE_VERSION = 1;
+const TOKEN_POOL_KEY = 'nightfallTokensPool';
+
+const { SHIELD_CONTRACT_NAME } = global.nightfallConstants;
+
+const storage = window.localStorage;
+
+function init() {
+  if (!storage.getItem(STORAGE_VERSION_KEY)) {
+    storage.setItem(STORAGE_VERSION_KEY, STORAGE_VERSION);
+  }
+}
+
+function tokensSet(userKey, tokens) {
+  init();
+  storage.setItem(TOKEN_POOL_KEY + userKey, JSON.stringify(tokens));
+}
+
+function tokensGet(userKey) {
+  const tokenString = storage.getItem(TOKEN_POOL_KEY + userKey);
+  return JSON.parse(tokenString);
+}
+
+function clear() {
+  storage.clear();
+}
+
+function ZkpPubKeyArraySet(userKey, zkpPubKeys) {
+  init();
+  storage.setItem(`${userKey}/zkpPubKeys`, JSON.stringify(zkpPubKeys));
+}
+
+function ZkpPubKeyArrayGet(userKey) {
+  return JSON.parse(storage.getItem(`${userKey}/zkpPubKeys`));
+}
+
+async function setPricing(tokenIDs) {
+  init();
+  const now = Date.now();
+  const pricingArray = await Promise.all(
+    tokenIDs.map(async t => {
+      const price = t ? await getPrice(t) : 0;
+      return {
+        id: t,
+        price,
+      };
+    }),
+  );
+  const pricingObject = pricingArray.reduce((acc, curr) => {
+    acc[curr.id] = curr.price;
+    return acc;
+  }, {});
+  storage.setItem(
+    'pricing',
+    JSON.stringify({
+      time: now,
+      ...pricingObject,
+    }),
+  );
+}
+
+function getPricing() {
+  const retrievedPrice = storage.getItem('pricing');
+  return JSON.parse(retrievedPrice);
+}
+
+async function shieldAddressSet() {
+  init();
+  const now = Date.now();
+  const storedAddress = storage.getItem('/shieldAddress');
+  try {
+    if (storedAddress === null || now - storedAddress.now > 1000 * 3600 * 24 * 1) {
+      const { address } = (await getContractAddress(SHIELD_CONTRACT_NAME)).data;
+      console.log('Address', address);
+      storage.setItem('/shieldAddress', JSON.stringify({ address, now }));
+    }
+  } catch (error) {
+    console.log('errr', error);
+    throw new Error('Could not get Shield Address');
+  }
+}
+
+function shieldAddressGet() {
+  const addressObj = storage.getItem('/shieldAddress');
+  if (!addressObj)
+    return shieldAddressSet().then(() => {
+      return shieldAddressGet();
+    });
+  const { address } = JSON.parse(storage.getItem('/shieldAddress'));
+  return address;
+}
+
+export {
+  tokensSet,
+  tokensGet,
+  clear,
+  ZkpPubKeyArrayGet,
+  ZkpPubKeyArraySet,
+  setPricing,
+  getPricing,
+  shieldAddressGet,
+  shieldAddressSet,
+};

--- a/aws/tmp/wallet/sendModal.tsx
+++ b/aws/tmp/wallet/sendModal.tsx
@@ -655,7 +655,10 @@ const SendModal = (props: SendModalProps): JSX.Element => {
                 <BalanceText>
                   <p>
                     ${' '}
-                    {new BigFloat(l2Balance, sendToken.decimals)
+                    {sendToken.decimals ? new BigFloat(l2Balance, sendToken.decimals)
+                      .mul(sendToken.currencyValue)
+                      .toFixed(4) : 
+                      new BigFloat(String(l2Balance).concat('.0000'), 4)
                       .mul(sendToken.currencyValue)
                       .toFixed(4)}
                   </p>


### PR DESCRIPTION
- Fix conversion factor when token decimals is 0
- Enable passing `id: ''` for coingecko api if we don't have any price to compare for the token.